### PR TITLE
Add speaker role tag to displayed transcript

### DIFF
--- a/apps/frontend/src/transcription/components/TranscriptListener.tsx
+++ b/apps/frontend/src/transcription/components/TranscriptListener.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 
 type TranscriptItem = {
-
+  text: string;
+  speaker: string;
+}; 
 
 const TranscriptListener = () => {
   const [transcripts, setTranscripts] = useState<TranscriptItem[]>([]);
@@ -40,6 +42,10 @@ const TranscriptListener = () => {
       socket.close();
     };
   }, []);
+
+    const getSpeakerTag = (role: string) => {
+
+  };
 
 
   return (

--- a/apps/frontend/src/transcription/components/TranscriptListener.tsx
+++ b/apps/frontend/src/transcription/components/TranscriptListener.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 
+type TranscriptItem = {
+
+
 const TranscriptListener = () => {
-  const [transcript, setTranscript] = useState("");
+  const [transcripts, setTranscripts] = useState<TranscriptItem[]>([]);
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
 
   useEffect(() => {
-    // Connection to the WebSocket
     const socket = new WebSocket("ws://localhost:5001/ws/transcripts");
 
     socket.onopen = () => {
@@ -17,15 +19,17 @@ const TranscriptListener = () => {
       if (data.status === "updated") {
         console.log("📡 Transcript updated from backend via WebSocket!");
         try {
-          
-          // Fetching the updated transcript
           const res = await fetch("http://localhost:5001/transcripts");
           const json = await res.json();
-          setTranscript(json.text);
-          setLastUpdated(new Date().toLocaleTimeString());
-          
-          await fetch("http://localhost:5001/generate", { method: "POST" });
 
+          if (Array.isArray(json.transcript)) {
+            setTranscripts(json.transcript);
+          } else {
+            console.warn("Transcript response was not an array:", json);
+          }
+
+          setLastUpdated(new Date().toLocaleTimeString());
+          await fetch("http://localhost:5001/generate", { method: "POST" });
         } catch (err) {
           console.error("Failed to fetch updated transcript:", err);
         }
@@ -37,6 +41,7 @@ const TranscriptListener = () => {
     };
   }, []);
 
+
   return (
     <div style={{
       maxWidth: "600px",
@@ -47,7 +52,15 @@ const TranscriptListener = () => {
       backgroundColor: "#fff"
     }}>
       <h2 style={{ color: "#4f46e5" }}>🧾 Live Transcript Feed</h2>
-      <p style={{ marginTop: "1rem", color: "#333" }}>{transcript || "Waiting for transcript..."}</p>
+      {transcripts.length === 0 ? (
+        <p style={{ marginTop: "1rem", color: "#333" }}>Waiting for transcript...</p>
+      ) : (
+        transcripts.map((item, index) => (
+          <p key={index} style={{ marginTop: "0.5rem", color: "#333" }}>
+            <strong>{getSpeakerTag(item.speaker)}</strong> {item.text}
+          </p>
+        ))
+      )}
       {lastUpdated && (
         <p style={{ marginTop: "1rem", fontSize: "0.9rem", color: "#666" }}>
           Last Updated: {lastUpdated}

--- a/apps/frontend/src/transcription/components/TranscriptListener.tsx
+++ b/apps/frontend/src/transcription/components/TranscriptListener.tsx
@@ -46,7 +46,7 @@ const TranscriptListener = () => {
     const getSpeakerTag = (role: string) => {
     if (!role) return "[Participant]";
     const lower = role.toLowerCase();
-    
+    return lower === "host" ? "[Host]" : "[Participant]";
   };
 
 

--- a/apps/frontend/src/transcription/components/TranscriptListener.tsx
+++ b/apps/frontend/src/transcription/components/TranscriptListener.tsx
@@ -44,7 +44,7 @@ const TranscriptListener = () => {
   }, []);
 
     const getSpeakerTag = (role: string) => {
-
+    if (!role) return "[Participant]";
   };
 
 

--- a/apps/frontend/src/transcription/components/TranscriptListener.tsx
+++ b/apps/frontend/src/transcription/components/TranscriptListener.tsx
@@ -45,6 +45,8 @@ const TranscriptListener = () => {
 
     const getSpeakerTag = (role: string) => {
     if (!role) return "[Participant]";
+    const lower = role.toLowerCase();
+    
   };
 
 


### PR DESCRIPTION
### What This PR Does

- Displays `[Host]` or `[Participant]` labels before each transcript line in the live transcript feed.
- Uses `speaker` field from the transcript response to determine the role.
- Improves clarity for viewers to understand who is speaking during the meeting.

### Technical Details

- Updates `TranscriptListener.tsx` to:
  - Fetch an array of `{ text, speaker }` objects from the `/transcripts` endpoint.
  - Loop through and display each line with a role-based tag.
- Introduces a `TranscriptItem` type for type safety and clarity.
- Adds fallback logic in case the `speaker` field is missing or undefined.

